### PR TITLE
add language parameter

### DIFF
--- a/metadata.py
+++ b/metadata.py
@@ -10,9 +10,11 @@ from clams.app import ClamsApp
 from clams.appmetadata import AppMetadata
 from lapps.discriminators import Uri
 from mmif import DocumentTypes, AnnotationTypes
+from whisper.tokenizer import LANGUAGES
 
 timeunit = "seconds"
 default_model_size = "tiny"
+default_language = "None"
 
 
 # DO NOT CHANGE the function name 
@@ -40,9 +42,16 @@ def appmetadata() -> AppMetadata:
         choices=['tiny', 'base', 'small', 'medium', 'large'],
         default=default_model_size
     )
-        
-        
-    
+
+    metadata.add_parameter(
+        name='modelLang', 
+        description='language picker',
+        type='string',
+        choices=list(LANGUAGES.keys()).append("None"),
+        default=default_language
+    )
+
+            
     return metadata
 
 


### PR DESCRIPTION
Per requests, now a user can specify the languages supported by whisper.
If not specified:
1. whisper should auto-detect a language
2. the output .mmif file should have the value of@language: "en" as the default.

Right now, the language parameter is set to be passed as query strings like other configurable parameters when running app-whisper-wrapper as an HTTP server. for example:
```
curl -H "Accept: application/json" -X POST -d@input.mmif -s http://localhost:5000?modelLang='zh' > output.mmif
```
Please let me know if other ways of passing the parameter is preferred