### PR TITLE
fix modelLang error

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,10 +43,17 @@ class WhisperWrapper(ClamsApp):
         if not docs:
             docs = mmif.get_documents_by_type(DocumentTypes.VideoDocument)
         lang = parameters['modelLang'].split('-')[0]
+        if lang and lang not in whisper.tokenizer.LANGUAGES:
+            raise ValueError(f"unsupported language code: {lang}. Check whisper/tokenizer.py")
+
         size = parameters['modelSize']
         if size in self.model_size_alias:
             size = self.model_size_alias[size]
-        if lang == 'en' and not size.startswith('large'):
+
+        # tiny, base, small, medium have English-only models. large and turbo do not.
+        # tiny.en, base.en, small.en, medium.en:
+        EN_MODELS = {'tiny', 'base', 'small', 'medium'}
+        if lang == 'en' and size in EN_MODELS:
             size += '.en'
         self.logger.debug(f'whisper model: {size} ({lang})')
         # taken from the default values for decoder arguments in whisper cli

--- a/metadata.py
+++ b/metadata.py
@@ -39,9 +39,9 @@ def appmetadata() -> AppMetadata:
     
     metadata.add_parameter(
         name='modelSize', 
-        description='The size of the model to use. When `modelLang=en` is given, for non-`large` models, '
+        description='The size of the model to use. When `modelLang=en` is given, for non-`large` and non -`turbo` models, '
                     'English-only models will be used instead of multilingual models for speed and accuracy. '
-                    '(For `large` models, English-only models are not available.) (also can be given as alias: '
+                    '(For `large` and `turbo` models, English-only models are not available.) (also can be given as alias: '
                     'tiny=t, base=b, small=s, medium=m, large=l, large-v2=l2, large-v3=l3, turbo=tu)',
         type='string',
         choices=['tiny', 't', 'base', 'b', 'small', 's', 'medium', 'm', 'large', 'l', 'large-v2', 'l2', 'large-v3', 'l3', 'turbo', 'tu'],


### PR DESCRIPTION
Fixed re-opened #17.  Handled models without `en` variants such as `large` and `turbo`, and added validation for supported language code. Updated the wording in `metadata.py`. 

